### PR TITLE
refactor: expose courgette clicker globals

### DIFF
--- a/courgette/js/main.js
+++ b/courgette/js/main.js
@@ -1,11 +1,8 @@
 // Courgette Clicker main script
 
-// Encapsulate all game logic inside an IIFE to prevent direct access to internal
-// variables from the browser console. This adds a basic layer of protection
-// against cheating by hiding the state object and helper functions from the
-// global scope. Only the DOM event handlers defined within this function
-// interact with the game state.
-(function() {
+// Main script runs in global scope so game state and helpers are directly
+// accessible. This simplifies debugging and integration at the cost of
+// exposing the internals publicly.
 
 // When defined before this script executes, setting window.COURGETTE_NO_CSS
 // to true prevents the game from altering page-wide CSS. This is useful when
@@ -3955,5 +3952,3 @@ function loadSavedGame() {
 // Start the locale loading
 loadLocale();
 
-// Immediately invoked function expression closure end
-})();


### PR DESCRIPTION
## Summary
- remove IIFE wrapper around Courgette Clicker's main script and expose internals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894987123f8832cb2510fbba3d86f67