### PR TITLE
Add Whack-a-Capy mini game

### DIFF
--- a/Capy/menu.js
+++ b/Capy/menu.js
@@ -98,6 +98,14 @@
       image: 'assets/capybara_ninja_new.png'
     },
     {
+      id: 'whack',
+      title: 'Whack‑a‑Capy',
+      scoreKey: 'capyWhackHighScore',
+      page: 'whack.html',
+      category: 'arcade',
+      image: 'assets/capybara_super_transparent.png'
+    },
+    {
       id: 'bombercapy',
       title: 'Bomber Capy',
       scoreKey: 'bomberCapyHighScore',

--- a/Capy/style.css
+++ b/Capy/style.css
@@ -1128,3 +1128,31 @@ body.dark-mode .dark-mode-toggle:hover {
   border-bottom: 10px solid transparent;
   border-left: 14px solid currentColor;
 }
+/* ---------------------- Whack-a-Capy ---------------------- */
+#whack-container {
+  position: relative;
+  margin: 0 auto;
+  width: 480px;
+  height: 360px;
+}
+#whackCanvas {
+  width: 100%;
+  height: 100%;
+  background: #c8e6c9;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+#whack-hud {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 20px;
+  padding: 4px 8px;
+  font-size: 1.1em;
+  background: rgba(0,0,0,0.4);
+  color: #fff;
+  border-radius: 4px;
+  pointer-events: none;
+}

--- a/Capy/whack.html
+++ b/Capy/whack.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Whack‑a‑Capy</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body data-force-landscape="false">
+    <div id="whack-container">
+      <canvas id="whackCanvas" width="480" height="360"></canvas>
+      <div id="whack-hud">
+        <span>Score : <span id="whack-score">0</span></span>
+        <span>Temps : <span id="whack-time">30</span>s</span>
+      </div>
+    </div>
+
+    <div id="whack-start" class="overlay">
+      <div class="menu-card">
+        <h1>Whack‑a‑Capy</h1>
+        <p>Attrape les capybaras qui apparaissent avant la fin du temps !</p>
+        <div class="button-group">
+          <button id="whack-start-btn" class="btn">Démarrer</button>
+          <button id="whack-menu-start" class="btn">Menu</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="whack-gameover" class="overlay hidden">
+      <div class="menu-card">
+        <h1>Terminé !</h1>
+        <p><strong>Score :</strong> <span id="whack-final-score">0</span></p>
+        <p><strong>Record :</strong> <span id="whack-high-score">0</span></p>
+        <div class="button-group">
+          <button id="whack-replay" class="btn">Rejouer</button>
+          <button id="whack-menu" class="btn">Menu</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="orientation-warning" class="orientation-warning hidden">
+      Veuillez tourner votre appareil en mode paysage !
+    </div>
+
+    <script src="config.js"></script>
+    <script src="whack.js"></script>
+    <script src="orientation.js"></script>
+  </body>
+</html>

--- a/Capy/whack.js
+++ b/Capy/whack.js
@@ -1,0 +1,96 @@
+(() => {
+  const canvas = document.getElementById('whackCanvas');
+  const ctx = canvas.getContext('2d');
+  const startOverlay = document.getElementById('whack-start');
+  const gameOverOverlay = document.getElementById('whack-gameover');
+  const scoreEl = document.getElementById('whack-score');
+  const timeEl = document.getElementById('whack-time');
+  const finalScoreEl = document.getElementById('whack-final-score');
+  const highScoreEl = document.getElementById('whack-high-score');
+
+  const sprite = new Image();
+  sprite.src = 'assets/capybara_super_transparent.png';
+
+  let capyX = 0;
+  let capyY = 0;
+  const size = 80;
+  let score = 0;
+  let time = 30;
+  let timerId = null;
+  let running = false;
+
+  function randomPos() {
+    capyX = Math.random() * (canvas.width - size);
+    capyY = Math.random() * (canvas.height - size);
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(sprite, capyX, capyY, size, size);
+  }
+
+  function startGame() {
+    score = 0;
+    time = 30;
+    scoreEl.textContent = '0';
+    timeEl.textContent = '30';
+    startOverlay.classList.add('hidden');
+    gameOverOverlay.classList.add('hidden');
+    randomPos();
+    draw();
+    running = true;
+    timerId = setInterval(() => {
+      time--;
+      timeEl.textContent = time;
+      if (time <= 0) {
+        endGame();
+      } else {
+        randomPos();
+        draw();
+      }
+    }, 1000);
+  }
+
+  function endGame() {
+    running = false;
+    clearInterval(timerId);
+    finalScoreEl.textContent = score;
+    let high = 0;
+    try {
+      const stored = localStorage.getItem('capyWhackHighScore');
+      if (stored !== null) high = parseInt(stored, 10) || 0;
+    } catch (e) {
+      high = 0;
+    }
+    if (score > high) {
+      high = score;
+      try {
+        localStorage.setItem('capyWhackHighScore', String(high));
+      } catch (e) {}
+    }
+    highScoreEl.textContent = high;
+    gameOverOverlay.classList.remove('hidden');
+  }
+
+  canvas.addEventListener('click', (e) => {
+    if (!running) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    if (x >= capyX && x <= capyX + size && y >= capyY && y <= capyY + size) {
+      score++;
+      scoreEl.textContent = score;
+      randomPos();
+      draw();
+    }
+  });
+
+  document.getElementById('whack-start-btn').addEventListener('click', startGame);
+  document.getElementById('whack-replay').addEventListener('click', startGame);
+  document.getElementById('whack-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('whack-menu-start').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+})();


### PR DESCRIPTION
## Summary
- add Whack-a-Capy click mini-game using existing assets
- style HUD and game area for clearer UI
- list new game in menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950add4078832ca744172bd6bb8076