### PR TITLE
Add Capy Battle mini game

### DIFF
--- a/Capy/battle.html
+++ b/Capy/battle.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Capy Battle</title>
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      .battle-container {
+        max-width: 480px;
+        margin: 0 auto;
+        text-align: center;
+        padding: 8px;
+      }
+      .battle-arena {
+        position: relative;
+        width: 100%;
+        height: 240px;
+        background: url('assets/swamp_background.png') center/cover no-repeat;
+        border-radius: 12px;
+        overflow: hidden;
+        margin-bottom: 12px;
+      }
+      .fighter {
+        position: absolute;
+        bottom: 0;
+        width: 120px;
+        transition: transform 0.3s;
+      }
+      #player { left: 20px; }
+      #enemy { right: 20px; transform: scaleX(-1); }
+      .hp-label { font-weight: bold; margin-top: 4px; }
+      .hp-bar {
+        height: 16px;
+        background: #f44336;
+        border-radius: 8px;
+        overflow: hidden;
+        margin-bottom: 8px;
+      }
+      .hp-fill {
+        height: 100%;
+        width: 100%;
+        background: #4caf50;
+        transition: width 0.3s;
+      }
+      #message { min-height: 40px; }
+      .attack-anim { transform: translateX(40px); }
+      .enemy-attack-anim { transform: translateX(-40px) scaleX(-1); }
+      .hit-anim { animation: hit 0.3s; }
+      @keyframes hit {
+        0% { transform: translateX(0); }
+        50% { transform: translateX(-10px); }
+        100% { transform: translateX(0); }
+      }
+      .victory-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: none;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0,0,0,0.6);
+        color: #fff;
+        font-size: 2em;
+        gap: 16px;
+      }
+      .victory-overlay.visible { display: flex; }
+      .star {
+        width: 80px;
+        animation: spin 2s linear infinite;
+      }
+      @keyframes spin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+      }
+    </style>
+  </head>
+  <body data-force-landscape="false">
+    <div class="battle-container">
+      <div class="battle-arena">
+        <img id="player" class="fighter" src="assets/capybara_super.png" alt="capy joueur" />
+        <img id="enemy" class="fighter" src="assets/capybara_turtle.png" alt="capy ennemi" />
+        <div id="result-overlay" class="victory-overlay">
+          <img src="assets/celebration_star.png" alt="étoile" class="star" />
+          <div id="result-text">Victoire !</div>
+          <button id="restart-btn" class="btn">Rejouer</button>
+        </div>
+      </div>
+      <div class="hp-label">Capy HP</div>
+      <div class="hp-bar"><div id="player-hp" class="hp-fill"></div></div>
+      <div class="hp-label">Ennemi HP</div>
+      <div class="hp-bar"><div id="enemy-hp" class="hp-fill"></div></div>
+      <p id="message">La bataille commence !</p>
+      <div>
+        <button id="attack-btn" class="btn">Attaquer</button>
+        <button id="menu-btn" class="btn">Menu</button>
+      </div>
+    </div>
+    <script src="config.js"></script>
+    <script src="battle.js"></script>
+    <script src="orientation.js"></script>
+  </body>
+</html>

--- a/Capy/battle.js
+++ b/Capy/battle.js
@@ -1,0 +1,123 @@
+(() => {
+  const playerImg = document.getElementById('player');
+  const enemyImg = document.getElementById('enemy');
+  const playerHpEl = document.getElementById('player-hp');
+  const enemyHpEl = document.getElementById('enemy-hp');
+  const msgEl = document.getElementById('message');
+  const attackBtn = document.getElementById('attack-btn');
+  const menuBtn = document.getElementById('menu-btn');
+  const resultOverlay = document.getElementById('result-overlay');
+  const restartBtn = document.getElementById('restart-btn');
+  const resultText = document.getElementById('result-text');
+  const starImg = resultOverlay.querySelector('.star');
+
+  let playerHp = 100;
+  let enemyHp = 100;
+  let inBattle = true;
+
+  // Charger les sons en utilisant le volume global s'il est défini.
+  const attackSound = new Audio('assets/sounds/beep6.wav');
+  const victorySound = new Audio('assets/sounds/fireworks.wav');
+  const bgMusic = new Audio('assets/audio/battle_trainer.ogg');
+  bgMusic.loop = true;
+  function applyVolume(audio) {
+    try {
+      const vol = parseFloat(localStorage.getItem('capyGlobalVolume'));
+      if (!isNaN(vol)) audio.volume = vol;
+    } catch (e) {}
+  }
+  [attackSound, victorySound, bgMusic].forEach(applyVolume);
+
+  function updateBars() {
+    playerHpEl.style.width = `${playerHp}%`;
+    enemyHpEl.style.width = `${enemyHp}%`;
+  }
+
+  function showMessage(text) {
+    msgEl.textContent = text;
+  }
+
+  function enemyAttack() {
+    if (!inBattle) return;
+    enemyImg.classList.add('enemy-attack-anim');
+    attackSound.currentTime = 0;
+    attackSound.play();
+    const dmg = Math.floor(Math.random() * 15) + 5;
+    setTimeout(() => {
+      enemyImg.classList.remove('enemy-attack-anim');
+      playerImg.classList.add('hit-anim');
+      playerHp = Math.max(0, playerHp - dmg);
+      updateBars();
+      showMessage(`L'ennemi inflige ${dmg} dégâts !`);
+      setTimeout(() => {
+        playerImg.classList.remove('hit-anim');
+        if (playerHp <= 0) {
+          endBattle(false);
+        } else {
+          attackBtn.disabled = false;
+        }
+      }, 300);
+    }, 300);
+  }
+
+  function playerAttack() {
+    if (!inBattle) return;
+    attackBtn.disabled = true;
+    playerImg.classList.add('attack-anim');
+    attackSound.currentTime = 0;
+    attackSound.play();
+    const dmg = Math.floor(Math.random() * 15) + 5;
+    setTimeout(() => {
+      playerImg.classList.remove('attack-anim');
+      enemyImg.classList.add('hit-anim');
+      enemyHp = Math.max(0, enemyHp - dmg);
+      updateBars();
+      showMessage(`Capy inflige ${dmg} dégâts !`);
+      setTimeout(() => {
+        enemyImg.classList.remove('hit-anim');
+        if (enemyHp <= 0) {
+          endBattle(true);
+        } else {
+          enemyAttack();
+        }
+      }, 300);
+    }, 300);
+  }
+
+  function endBattle(victory) {
+    inBattle = false;
+    if (victory) {
+      resultText.textContent = 'Victoire !';
+      starImg.style.display = 'block';
+      victorySound.play();
+    } else {
+      resultText.textContent = 'Défaite…';
+      starImg.style.display = 'none';
+      bgMusic.pause();
+    }
+    resultOverlay.classList.add('visible');
+  }
+
+  // Boutons
+  if (attackBtn) {
+    attackBtn.addEventListener('click', playerAttack);
+  }
+  if (menuBtn) {
+    menuBtn.addEventListener('click', () => {
+      window.location.href = '../Capy/games.html';
+    });
+  }
+  if (restartBtn) {
+    restartBtn.addEventListener('click', () => {
+      window.location.reload();
+    });
+  }
+
+  // Démarrage de la musique lorsque le jeu commence
+  window.addEventListener('capyGameStart', () => {
+    applyVolume(bgMusic);
+    try { bgMusic.play(); } catch (e) {}
+  });
+
+  updateBars();
+})();

--- a/Capy/menu.js
+++ b/Capy/menu.js
@@ -182,6 +182,16 @@
       category: 'casino',
       image: 'assets/roulette_icon.png'
     }
+    ,
+    // Mini-jeu de bataille simple avec animations et retour positif.
+    {
+      id: 'battle',
+      title: 'Capy Battle',
+      scoreKey: 'capyBattleHighScore',
+      page: 'battle.html',
+      category: 'arcade',
+      image: 'assets/capybara_super.png'
+    }
     // (Entrée de jeu Courgette Clicker retirée.  Ce jeu externe est désormais
     // accessible via un bouton dédié dans l’en‑tête de la page d’accueil.)
   ];


### PR DESCRIPTION
## Summary
- add Capy Battle mini game with HP bars, battle animations, and victory overlay using existing assets
- register the new battle in the main menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950da2fea0832cb1394cc7db4520d8