### PR TITLE
Refactor Flying Capy and add Tap Capy Phaser game

### DIFF
--- a/Capy/flappy_phaser.js
+++ b/Capy/flappy_phaser.js
@@ -1,3 +1,135 @@
+const GAP = 140;
+
+class FlappyCapyScene extends Phaser.Scene {
+  constructor() {
+    super('FlappyCapy');
+  }
+
+  preload() {
+    this.load.image('capy', 'assets/capybara_flying.png');
+    this.load.image('bg', 'assets/bamboo_bg.png');
+  }
+
+  create() {
+    this.score = 0;
+    this.add
+      .image(this.scale.width / 2, this.scale.height / 2, 'bg')
+      .setDisplaySize(this.scale.width, this.scale.height);
+
+    this.capy = this.physics
+      .add.sprite(100, this.scale.height / 2, 'capy')
+      .setScale(0.5);
+    this.capy.setCollideWorldBounds(true);
+
+    this.pipes = this.physics.add.group();
+    this.cursors = this.input.keyboard.createCursorKeys();
+
+    this.scoreText = this.add.text(10, 10, '0', {
+      font: '20px Arial',
+      fill: '#fff'
+    });
+
+    this.tapText = this.add
+      .text(this.scale.width / 2, this.scale.height / 2, 'Tap to start', {
+        font: '28px Arial',
+        fill: '#fff'
+      })
+      .setOrigin(0.5);
+
+    this.physics.pause();
+    this.input.once('pointerdown', this.startGame, this);
+    this.input.keyboard.once('keydown-SPACE', this.startGame, this);
+
+    this.physics.add.collider(
+      this.capy,
+      this.pipes,
+      this.gameOver,
+      null,
+      this
+    );
+  }
+
+  startGame() {
+    this.tapText.destroy();
+    this.physics.resume();
+    this.spawnPipes();
+    this.time.addEvent({
+      delay: 1500,
+      callback: this.spawnPipes,
+      callbackScope: this,
+      loop: true
+    });
+    this.gameState = 'playing';
+  }
+
+  update() {
+    if (this.gameState !== 'playing') return;
+
+    if (this.cursors.space.isDown || this.cursors.up.isDown) {
+      this.flap();
+    }
+    this.pipes.getChildren().forEach((pipe) => {
+      if (!pipe.scored && pipe.isTop && pipe.x + pipe.width / 2 < this.capy.x) {
+        pipe.scored = true;
+        this.score += 1;
+        this.scoreText.setText(this.score);
+      }
+      if (pipe.x < -50) {
+        pipe.destroy();
+      }
+    });
+  }
+
+  flap() {
+    this.capy.setVelocityY(-300);
+  }
+
+  spawnPipes() {
+    const topHeight = Phaser.Math.Between(50, this.scale.height - GAP - 50);
+    const bottomY = topHeight + GAP;
+
+    const top = this.add.rectangle(
+      this.scale.width,
+      topHeight / 2,
+      50,
+      topHeight,
+      0x90a4ae
+    );
+    const bottomHeight = this.scale.height - bottomY;
+    const bottom = this.add.rectangle(
+      this.scale.width,
+      bottomY + bottomHeight / 2,
+      50,
+      bottomHeight,
+      0x90a4ae
+    );
+
+    this.physics.add.existing(top);
+    this.physics.add.existing(bottom);
+    top.body.setVelocityX(-200).setImmovable(true).setAllowGravity(false);
+    bottom.body.setVelocityX(-200).setImmovable(true).setAllowGravity(false);
+    top.isTop = true;
+    top.scored = false;
+
+    this.pipes.add(top);
+    this.pipes.add(bottom);
+  }
+
+  gameOver() {
+    this.gameState = 'gameover';
+    this.physics.pause();
+    this.capy.setTint(0xff0000);
+    this.add
+      .text(this.scale.width / 2, this.scale.height / 2, 'Game Over\nTap to restart', {
+        font: '28px Arial',
+        fill: '#fff',
+        align: 'center'
+      })
+      .setOrigin(0.5);
+    this.input.once('pointerdown', () => this.scene.restart(), this);
+  }
+}
+
 const config = {
   type: Phaser.AUTO,
   width: 480,
@@ -6,81 +138,8 @@ const config = {
     default: 'arcade',
     arcade: { gravity: { y: 800 }, debug: false }
   },
-  scene: { preload, create, update }
+  scene: FlappyCapyScene
 };
 
-let capy;
-let pipes;
-let cursors;
-let score = 0;
-let scoreText;
-const GAP = 140;
-
-function preload() {
-  this.load.image('capy', 'assets/capybara_flying.png');
-}
-
-function create() {
-  capy = this.physics.add.sprite(100, config.height / 2, 'capy').setScale(0.5);
-  capy.setCollideWorldBounds(true);
-
-  pipes = this.physics.add.group();
-  spawnPipes.call(this);
-  this.time.addEvent({ delay: 1500, callback: spawnPipes, callbackScope: this, loop: true });
-
-  cursors = this.input.keyboard.createCursorKeys();
-  this.input.on('pointerdown', flap, this);
-
-  scoreText = this.add.text(10, 10, '0', { font: '20px Arial', fill: '#fff' });
-  this.physics.add.collider(capy, pipes, gameOver, null, this);
-}
-
-function update() {
-  if (cursors.space.isDown || cursors.up.isDown) {
-    flap.call(this);
-  }
-  pipes.getChildren().forEach((pipe) => {
-    if (!pipe.scored && pipe.isTop && pipe.x + pipe.width / 2 < capy.x) {
-      pipe.scored = true;
-      score += 1;
-      scoreText.setText(score);
-    }
-    if (pipe.x < -50) {
-      pipe.destroy();
-    }
-  });
-}
-
-function flap() {
-  capy.setVelocityY(-300);
-}
-
-function spawnPipes() {
-  const topHeight = Phaser.Math.Between(50, config.height - GAP - 50);
-  const bottomY = topHeight + GAP;
-
-  const top = this.add.rectangle(config.width, topHeight / 2, 50, topHeight, 0x90a4ae);
-  const bottomHeight = config.height - bottomY;
-  const bottom = this.add.rectangle(config.width, bottomY + bottomHeight / 2, 50, bottomHeight, 0x90a4ae);
-
-  this.physics.add.existing(top);
-  this.physics.add.existing(bottom);
-  top.body.setVelocityX(-200).setImmovable(true).setAllowGravity(false);
-  bottom.body.setVelocityX(-200).setImmovable(true).setAllowGravity(false);
-  top.isTop = true;
-  top.scored = false;
-
-  pipes.add(top);
-  pipes.add(bottom);
-}
-
-function gameOver() {
-  this.physics.pause();
-  capy.setTint(0xff0000);
-  this.input.once('pointerdown', () => {
-    score = 0;
-    this.scene.restart();
-  });
-}
-
 new Phaser.Game(config);
+

--- a/Capy/menu.js
+++ b/Capy/menu.js
@@ -98,6 +98,14 @@
       image: 'assets/capybara_ninja_new.png'
     },
     {
+      id: 'tapcapy',
+      title: 'Tap Capy',
+      scoreKey: 'tapCapyHighScore',
+      page: 'tap_phaser.html',
+      category: 'arcade',
+      image: 'assets/capybara_running_clear.png'
+    },
+    {
       id: 'whack',
       title: 'Whack‑a‑Capy',
       scoreKey: 'capyWhackHighScore',

--- a/Capy/tap_phaser.html
+++ b/Capy/tap_phaser.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tap Capy – Phaser</title>
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <script src="tap_phaser.js"></script>
+  </body>
+</html>
+

--- a/Capy/tap_phaser.js
+++ b/Capy/tap_phaser.js
@@ -1,0 +1,79 @@
+const GAME_DURATION = 15000;
+
+class TapCapyScene extends Phaser.Scene {
+  constructor() {
+    super('TapCapy');
+  }
+
+  preload() {
+    this.load.image('capy', 'assets/capybara_running_clear.png');
+    this.load.image('bg', 'assets/swamp_background.png');
+  }
+
+  create() {
+    this.score = 0;
+    this.add
+      .image(this.scale.width / 2, this.scale.height / 2, 'bg')
+      .setDisplaySize(this.scale.width, this.scale.height);
+
+    this.capy = this.add
+      .sprite(this.scale.width / 2, this.scale.height / 2, 'capy')
+      .setScale(0.5)
+      .setInteractive();
+    this.capy.on('pointerdown', this.handleTap, this);
+
+    this.scoreText = this.add.text(10, 10, '0', {
+      font: '20px Arial',
+      fill: '#fff'
+    });
+
+    this.moveTimer = this.time.addEvent({
+      delay: 1000,
+      callback: this.moveCapy,
+      callbackScope: this,
+      loop: true
+    });
+
+    this.time.delayedCall(GAME_DURATION, this.endGame, [], this);
+  }
+
+  handleTap() {
+    this.score++;
+    this.scoreText.setText(this.score);
+    this.moveCapy();
+  }
+
+  moveCapy() {
+    const x = Phaser.Math.Between(50, this.scale.width - 50);
+    const y = Phaser.Math.Between(50, this.scale.height - 50);
+    this.capy.setPosition(x, y);
+  }
+
+  endGame() {
+    this.moveTimer.remove(false);
+    this.capy.disableInteractive();
+    this.add
+      .text(
+        this.scale.width / 2,
+        this.scale.height / 2,
+        `Time's up!\nScore: ${this.score}\nTap to restart`,
+        {
+          font: '28px Arial',
+          fill: '#fff',
+          align: 'center'
+        }
+      )
+      .setOrigin(0.5);
+    this.input.once('pointerdown', () => this.scene.restart(), this);
+  }
+}
+
+const config = {
+  type: Phaser.AUTO,
+  width: 480,
+  height: 640,
+  scene: TapCapyScene
+};
+
+new Phaser.Game(config);
+


### PR DESCRIPTION
## Summary
- Refactor Flying Capy to use a Phaser scene with start and game-over UI
- Add simple Tap Capy Phaser mini-game and hook it into the menu

## Testing
- `node --check Capy/flappy_phaser.js`
- `node --check Capy/tap_phaser.js`
- `node --check Capy/menu.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950e6fa888832caa5adea98c50603a