### PR TITLE
Add three puzzle mini-games with enhanced UI

### DIFF
--- a/Capy/lights.html
+++ b/Capy/lights.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Capy Lights</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body data-force-landscape="false">
+    <button id="volume-toggle" class="volume-btn">🔇</button>
+    <div id="lights-container" class="courgette-container">
+      <canvas id="lightsCanvas" width="400" height="400"></canvas>
+      <div class="courgette-sidebar">
+        <p>Temps : <span id="lights-time">0</span>s</p>
+        <p>Coups : <span id="lights-moves">0</span></p>
+        <button id="lights-restart" class="btn">Rejouer</button>
+        <button id="lights-menu" class="btn">Menu</button>
+      </div>
+    </div>
+    <div id="lights-gameover" class="overlay hidden">
+      <div class="menu-card">
+        <h1>Puzzle terminé !</h1>
+        <p><strong>Temps :</strong> <span id="lights-current-time">0</span>s</p>
+        <p><strong>Record :</strong> <span id="lights-high-score">–</span>s</p>
+        <div class="button-group">
+          <button id="lights-over-replay" class="btn">Rejouer</button>
+          <button id="lights-over-menu" class="btn">Menu</button>
+        </div>
+      </div>
+    </div>
+    <div id="lights-instructions" class="overlay hidden">
+      <div class="menu-card">
+        <h2>Capy Lights – Règles</h2>
+        <p>Cliquez sur une case pour inverser son état ainsi que celui de ses voisines. Éteignez toutes les lumières le plus vite possible !</p>
+        <button id="lights-instructions-ok" class="btn">Ok</button>
+      </div>
+    </div>
+    <div id="orientation-warning" class="orientation-warning hidden">
+      Veuillez tourner votre appareil en mode paysage !
+    </div>
+    <script src="config.js"></script>
+    <script src="lights.js"></script>
+    <script src="orientation.js"></script>
+  </body>
+</html>

--- a/Capy/lights.js
+++ b/Capy/lights.js
@@ -1,0 +1,96 @@
+(() => {
+  const size = 5;
+  const canvas = document.getElementById('lightsCanvas');
+  const ctx = canvas.getContext('2d');
+  const tileSize = canvas.width / size;
+  let grid = [];
+  let moves = 0;
+  let time = 0;
+  let timer = null;
+
+  function init() {
+    grid = Array.from({ length: size }, () => Array.from({ length: size }, () => Math.random() < 0.5));
+    moves = 0;
+    time = 0;
+    updateUI();
+    draw();
+    if (timer) clearInterval(timer);
+    timer = setInterval(() => {
+      time++;
+      document.getElementById('lights-time').textContent = time;
+    }, 1000);
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        ctx.fillStyle = grid[y][x] ? '#ffc107' : '#37474f';
+        ctx.fillRect(x * tileSize + 1, y * tileSize + 1, tileSize - 2, tileSize - 2);
+      }
+    }
+  }
+
+  function toggle(x, y) {
+    if (x >= 0 && x < size && y >= 0 && y < size) {
+      grid[y][x] = !grid[y][x];
+    }
+  }
+
+  function handleClick(e) {
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.floor((e.clientX - rect.left) / tileSize);
+    const y = Math.floor((e.clientY - rect.top) / tileSize);
+    toggle(x, y);
+    toggle(x + 1, y);
+    toggle(x - 1, y);
+    toggle(x, y + 1);
+    toggle(x, y - 1);
+    moves++;
+    updateUI();
+    draw();
+    if (checkWin()) endGame();
+  }
+
+  function checkWin() {
+    return grid.every(row => row.every(cell => !cell));
+  }
+
+  function endGame() {
+    clearInterval(timer);
+    document.getElementById('lights-current-time').textContent = time;
+    let best = parseInt(localStorage.getItem('capyLightsHighScore') || '0', 10);
+    if (!best || time < best) {
+      localStorage.setItem('capyLightsHighScore', time);
+      best = time;
+    }
+    document.getElementById('lights-high-score').textContent = best;
+    document.getElementById('lights-gameover').classList.remove('hidden');
+  }
+
+  function updateUI() {
+    document.getElementById('lights-moves').textContent = moves;
+  }
+
+  canvas.addEventListener('click', handleClick);
+
+  document.getElementById('lights-restart').addEventListener('click', init);
+  document.getElementById('lights-over-replay').addEventListener('click', () => {
+    document.getElementById('lights-gameover').classList.add('hidden');
+    init();
+  });
+  document.getElementById('lights-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('lights-over-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('lights-instructions-ok').addEventListener('click', () => {
+    document.getElementById('lights-instructions').classList.add('hidden');
+  });
+
+  window.addEventListener('load', () => {
+    document.getElementById('lights-instructions').classList.remove('hidden');
+    init();
+  });
+})();

--- a/Capy/match.html
+++ b/Capy/match.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Capy Match</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body data-force-landscape="false">
+    <button id="volume-toggle" class="volume-btn">🔇</button>
+    <div id="match-container" class="courgette-container">
+      <div id="match-grid" class="match-grid"></div>
+      <div class="courgette-sidebar">
+        <p>Paires : <span id="match-pairs">0</span>/4</p>
+        <p>Temps : <span id="match-time">0</span>s</p>
+        <button id="match-restart" class="btn">Rejouer</button>
+        <button id="match-menu" class="btn">Menu</button>
+      </div>
+    </div>
+    <div id="match-gameover" class="overlay hidden">
+      <div class="menu-card">
+        <h1>Bravo !</h1>
+        <p><strong>Temps :</strong> <span id="match-current-time">0</span>s</p>
+        <p><strong>Record :</strong> <span id="match-high-score">–</span>s</p>
+        <div class="button-group">
+          <button id="match-over-replay" class="btn">Rejouer</button>
+          <button id="match-over-menu" class="btn">Menu</button>
+        </div>
+      </div>
+    </div>
+    <div id="match-instructions" class="overlay hidden">
+      <div class="menu-card">
+        <h2>Capy Match – Règles</h2>
+        <p>Retournez les cartes et retrouvez toutes les paires de légumes identiques. Essayez de terminer en un minimum de temps !</p>
+        <button id="match-instructions-ok" class="btn">Ok</button>
+      </div>
+    </div>
+    <div id="orientation-warning" class="orientation-warning hidden">
+      Veuillez tourner votre appareil en mode paysage !
+    </div>
+    <script src="config.js"></script>
+    <script src="match.js"></script>
+    <script src="orientation.js"></script>
+  </body>
+</html>

--- a/Capy/match.js
+++ b/Capy/match.js
@@ -1,0 +1,115 @@
+(() => {
+  const images = [
+    'assets/veg_carrot_final.png',
+    'assets/veg_courgette_final.png',
+    'assets/veg_pepper_final.png',
+    'assets/veg_tomato_final.png'
+  ];
+  let deck = [];
+  let first = null;
+  let lock = false;
+  let pairs = 0;
+  let time = 0;
+  let timer = null;
+
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function buildDeck() {
+    deck = shuffle(images.concat(images));
+    const grid = document.getElementById('match-grid');
+    grid.innerHTML = '';
+    deck.forEach((src, idx) => {
+      const card = document.createElement('div');
+      card.className = 'match-card';
+      card.dataset.index = idx.toString();
+      const img = document.createElement('img');
+      img.src = src;
+      img.alt = '';
+      card.appendChild(img);
+      card.addEventListener('click', () => onCard(card));
+      grid.appendChild(card);
+    });
+  }
+
+  function onCard(card) {
+    if (lock || card.classList.contains('revealed') || card.classList.contains('matched')) return;
+    if (!timer) {
+      timer = setInterval(() => {
+        time++;
+        document.getElementById('match-time').textContent = time;
+      }, 1000);
+    }
+    card.classList.add('revealed');
+    if (!first) {
+      first = card;
+    } else {
+      lock = true;
+      const second = card;
+      const same = deck[first.dataset.index] === deck[second.dataset.index];
+      setTimeout(() => {
+        if (same) {
+          first.classList.add('matched');
+          second.classList.add('matched');
+          pairs++;
+          document.getElementById('match-pairs').textContent = pairs;
+          if (pairs === deck.length / 2) endGame();
+        } else {
+          first.classList.remove('revealed');
+          second.classList.remove('revealed');
+        }
+        first = null;
+        lock = false;
+      }, 600);
+    }
+  }
+
+  function init() {
+    pairs = 0;
+    time = 0;
+    first = null;
+    lock = false;
+    document.getElementById('match-pairs').textContent = '0';
+    document.getElementById('match-time').textContent = '0';
+    if (timer) clearInterval(timer);
+    timer = null;
+    buildDeck();
+  }
+
+  function endGame() {
+    clearInterval(timer);
+    document.getElementById('match-current-time').textContent = time;
+    let best = parseInt(localStorage.getItem('capyMatchHighScore') || '0', 10);
+    if (!best || time < best) {
+      localStorage.setItem('capyMatchHighScore', time);
+      best = time;
+    }
+    document.getElementById('match-high-score').textContent = best;
+    document.getElementById('match-gameover').classList.remove('hidden');
+  }
+
+  document.getElementById('match-restart').addEventListener('click', init);
+  document.getElementById('match-over-replay').addEventListener('click', () => {
+    document.getElementById('match-gameover').classList.add('hidden');
+    init();
+  });
+  document.getElementById('match-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('match-over-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('match-instructions-ok').addEventListener('click', () => {
+    document.getElementById('match-instructions').classList.add('hidden');
+  });
+
+  window.addEventListener('load', () => {
+    document.getElementById('match-instructions').classList.remove('hidden');
+    init();
+  });
+})();

--- a/Capy/menu.js
+++ b/Capy/menu.js
@@ -207,7 +207,31 @@
       page: 'battle.html',
       category: 'arcade',
       image: 'assets/capybara_super.png'
-    }
+    },
+    {
+      id: 'lights',
+      title: 'Capy Lights',
+      scoreKey: 'capyLightsHighScore',
+      page: 'lights.html',
+      category: 'logique',
+      image: 'assets/icon_sun.png'
+    },
+    {
+      id: 'match',
+      title: 'Capy Match',
+      scoreKey: 'capyMatchHighScore',
+      page: 'match.html',
+      category: 'logique',
+      image: 'assets/capy_memory_icon.png'
+    },
+    {
+      id: 'scramble',
+      title: 'Capy Scramble',
+      scoreKey: 'capyScrambleHighScore',
+      page: 'scramble.html',
+      category: 'logique',
+      image: 'assets/capybara_penguin.png'
+    },
     // (Entrée de jeu Courgette Clicker retirée.  Ce jeu externe est désormais
     // accessible via un bouton dédié dans l’en‑tête de la page d’accueil.)
   ];

--- a/Capy/scramble.html
+++ b/Capy/scramble.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Capy Scramble</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body data-force-landscape="false">
+    <button id="volume-toggle" class="volume-btn">🔇</button>
+    <div id="scramble-container" class="courgette-container">
+      <div id="scramble-main" class="scramble-main">
+        <p id="scramble-scrambled" class="scramble-word"></p>
+        <div id="scramble-letters" class="scramble-letters"></div>
+        <p>Réponse : <span id="scramble-answer"></span></p>
+      </div>
+      <div class="courgette-sidebar">
+        <p>Temps : <span id="scramble-time">0</span>s</p>
+        <button id="scramble-restart" class="btn">Rejouer</button>
+        <button id="scramble-menu" class="btn">Menu</button>
+      </div>
+    </div>
+    <div id="scramble-gameover" class="overlay hidden">
+      <div class="menu-card">
+        <h1>Bien joué !</h1>
+        <p><strong>Temps :</strong> <span id="scramble-current-time">0</span>s</p>
+        <p><strong>Record :</strong> <span id="scramble-high-score">–</span>s</p>
+        <div class="button-group">
+          <button id="scramble-over-replay" class="btn">Rejouer</button>
+          <button id="scramble-over-menu" class="btn">Menu</button>
+        </div>
+      </div>
+    </div>
+    <div id="scramble-instructions" class="overlay hidden">
+      <div class="menu-card">
+        <h2>Capy Scramble – Règles</h2>
+        <p>Remettez les lettres dans le bon ordre pour retrouver le nom du légume caché.</p>
+        <button id="scramble-instructions-ok" class="btn">Ok</button>
+      </div>
+    </div>
+    <div id="orientation-warning" class="orientation-warning hidden">
+      Veuillez tourner votre appareil en mode paysage !
+    </div>
+    <script src="config.js"></script>
+    <script src="scramble.js"></script>
+    <script src="orientation.js"></script>
+  </body>
+</html>

--- a/Capy/scramble.js
+++ b/Capy/scramble.js
@@ -1,0 +1,76 @@
+(() => {
+  const words = ['CAROTTE', 'COURGETTE', 'TOMATE', 'PIMENT', 'PATATE'];
+  let target = '';
+  let answer = '';
+  let time = 0;
+  let timer = null;
+
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function init() {
+    target = words[Math.floor(Math.random() * words.length)];
+    answer = '';
+    time = 0;
+    document.getElementById('scramble-time').textContent = '0';
+    document.getElementById('scramble-answer').textContent = '';
+    const scrambled = shuffle([...target]).join('');
+    document.getElementById('scramble-scrambled').textContent = scrambled;
+    const container = document.getElementById('scramble-letters');
+    container.innerHTML = '';
+    for (const ch of scrambled) {
+      const btn = document.createElement('button');
+      btn.textContent = ch;
+      btn.className = 'scramble-letter';
+      btn.addEventListener('click', () => {
+        answer += ch;
+        document.getElementById('scramble-answer').textContent = answer;
+        btn.disabled = true;
+        if (answer === target) endGame();
+      });
+      container.appendChild(btn);
+    }
+    if (timer) clearInterval(timer);
+    timer = setInterval(() => {
+      time++;
+      document.getElementById('scramble-time').textContent = time;
+    }, 1000);
+  }
+
+  function endGame() {
+    clearInterval(timer);
+    document.getElementById('scramble-current-time').textContent = time;
+    let best = parseInt(localStorage.getItem('capyScrambleHighScore') || '0', 10);
+    if (!best || time < best) {
+      localStorage.setItem('capyScrambleHighScore', time);
+      best = time;
+    }
+    document.getElementById('scramble-high-score').textContent = best;
+    document.getElementById('scramble-gameover').classList.remove('hidden');
+  }
+
+  document.getElementById('scramble-restart').addEventListener('click', init);
+  document.getElementById('scramble-over-replay').addEventListener('click', () => {
+    document.getElementById('scramble-gameover').classList.add('hidden');
+    init();
+  });
+  document.getElementById('scramble-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('scramble-over-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('scramble-instructions-ok').addEventListener('click', () => {
+    document.getElementById('scramble-instructions').classList.add('hidden');
+  });
+
+  window.addEventListener('load', () => {
+    document.getElementById('scramble-instructions').classList.remove('hidden');
+    init();
+  });
+})();

--- a/Capy/style.css
+++ b/Capy/style.css
@@ -1156,3 +1156,65 @@ body.dark-mode .dark-mode-toggle:hover {
   border-radius: 4px;
   pointer-events: none;
 }
+/* ---------------------- Capy Lights ---------------------- */
+#lightsCanvas {
+  background: #263238;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+
+/* ---------------------- Capy Match ---------------------- */
+.match-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 70px);
+  gap: 8px;
+  padding: 8px;
+  justify-content: center;
+}
+.match-card {
+  width: 70px;
+  height: 70px;
+  background: #c8e6c9;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+.match-card img {
+  width: 60px;
+  height: 60px;
+  pointer-events: none;
+}
+.match-card.revealed {
+  background: #fff;
+}
+.match-card.matched {
+  visibility: hidden;
+}
+
+/* ---------------------- Capy Scramble ---------------------- */
+.scramble-main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+}
+.scramble-word {
+  font-size: 1.4em;
+  letter-spacing: 4px;
+}
+.scramble-letters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+}
+.scramble-letter {
+  padding: 8px 12px;
+  font-size: 1.2em;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Add Capy Lights, a lights-out puzzle built on a 5x5 grid
- Add Capy Match, a card matching puzzle using vegetable art
- Add Capy Scramble, a word scramble challenge
- Integrate games into menu and shared stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689510906850832c82b973e139d615e8