### PR TITLE
Improve mobile viewport handling and refresh stylesheet

### DIFF
--- a/Capy/action.html
+++ b/Capy/action.html
@@ -2,12 +2,12 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- Empêcher l'indexation automatique de cette page de jeu.  Les robots
          des moteurs de recherche n'exploreront ni ne suivront les liens de cette page. -->
     <meta name="robots" content="noindex,nofollow" />
     <title>Capy Mémoire</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- Capy Mémoire : jeu de mémoire sur l'étang.  Des nénuphars
        s'illuminent dans une séquence aléatoire.  Votre objectif est

--- a/Capy/battle.html
+++ b/Capy/battle.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy Battle</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
     <style>
       .battle-container {
         max-width: 480px;

--- a/Capy/blackjack.html
+++ b/Capy/blackjack.html
@@ -2,13 +2,13 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- Limiter l'indexation des moteurs de recherche pour cette page de jeu.  En
          ajoutant noindex,nofollow, on réduit la probabilité de scraping
          automatique des URLs internes. -->
     <meta name="robots" content="noindex,nofollow" />
     <title>Capy Blackjack</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
     <style>
       /* Mise en forme spécifique au blackjack avec une palette sobre et
          responsive.  Le conteneur est centré et occupe la majorité de

--- a/Capy/bomber.html
+++ b/Capy/bomber.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy Bomber</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- Ce jeu impose le mode paysage car le labyrinthe est large. -->
   <body data-force-landscape="true">

--- a/Capy/bomber_levels.html
+++ b/Capy/bomber_levels.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Bomber Capy – Niveaux</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- La sélection de niveaux de Bomber Capy peut être utilisée en mode
        portrait ou paysage.  Aucune contrainte d'orientation n'est

--- a/Capy/capymon.html
+++ b/Capy/capymon.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy Mon</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
     <style>
       /* Styles spécifiques pour Capy Mon */
       .capymon-container {

--- a/Capy/capymon.js
+++ b/Capy/capymon.js
@@ -1787,7 +1787,7 @@
   const moveDefinitions = {
     // Chaque attaque est dotée d’une puissance ou d’un soin ainsi que
     // d’une animation correspondante.  Les animations sont déclarées
-    // dans style.css et activées lors des combats si animationsOn est
+    // dans style_v2.css et activées lors des combats si animationsOn est
     // vrai dans les options.
     Charge: { power: 5, anim: 'anim-shake' },
     'Carapace': { power: 3, anim: 'anim-pulse' },

--- a/Capy/catch.html
+++ b/Capy/catch.html
@@ -2,10 +2,10 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy Catch</title>
     <!-- Feuille de style partagée par tous les jeux -->
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- Ce jeu peut être joué aussi bien en portrait qu'en paysage.  On
        utilise data‑force‑landscape="false" pour que l'overlay

--- a/Capy/courgette.html
+++ b/Capy/courgette.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Courgette Crush</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="false">
     <button id="volume-toggle" class="volume-btn">🔇</button>

--- a/Capy/credits.html
+++ b/Capy/credits.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Crédits</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="false">
     <div class="overlay" style="background: rgba(0,0,0,0.6);">

--- a/Capy/docs/CHANGELOG.md
+++ b/Capy/docs/CHANGELOG.md
@@ -31,7 +31,7 @@ Toutes les modifications significatives apportées à ce projet seront consigné
 
 ### Changed
 
-* Ajout des fichiers `index.html`, `style.css` et `main.js` implémentant la structure initiale du jeu, sa logique principale, la génération des obstacles et des bonus ainsi que les effets sonores.
+* Ajout des fichiers `index.html`, `style_v2.css` et `main.js` implémentant la structure initiale du jeu, sa logique principale, la génération des obstacles et des bonus ainsi que les effets sonores.
 * Mise à jour de `tree.txt` pour refléter la nouvelle arborescence et ajout de l’auto‑redimensionnement du canvas.
 
 ## [1.0.0] - 2025-08-04

--- a/Capy/docs/README.md
+++ b/Capy/docs/README.md
@@ -53,7 +53,7 @@ La structure générale est décrite dans le fichier `tree.txt` généré à cha
 
 * `index.html` : page web principale qui charge le jeu.
 * `main.js` : logique JavaScript du jeu (mouvement, collisions, interface, bonus, etc.).
-* `style.css` : styles CSS pour l’interface.
+* `style_v2.css` : styles CSS pour l’interface.
 * `assets/` : contient les images SVG/PNG et éventuellement les sons générés.
 * `progress_log.md` : journal chronologique des étapes réalisées, avec date et explications.
 * `agents.md` : description des rôles et tâches lors de la conception.

--- a/Capy/docs/progress_log.md
+++ b/Capy/docs/progress_log.md
@@ -14,7 +14,7 @@ Ce journal retrace les différentes étapes de développement du jeu **Flappy C
 
 * Mise en place de l’ossature du jeu en HTML, CSS et JavaScript :
   * Création de `index.html` avec un canvas pour afficher le jeu et deux overlays (menu principal et écran Game Over) comportant boutons et score.
-  * Élaboration de `style.css` pour styliser le fond, les boutons et les overlays de manière simple et cohérente.
+  * Élaboration de `style_v2.css` pour styliser le fond, les boutons et les overlays de manière simple et cohérente.
   * Implémentation du fichier `main.js` contenant l’ensemble de la logique du jeu : gestion des états (menu, jeu, fin de partie), classe Capybara avec sa propre physique (gravité, saut, rotation pour l’inertie), génération et dessin des obstacles ainsi que des bonus, détection de collisions et gestion des scores.
   * Ajout d’un système de bonus (« score » et « invincible ») et d’une invincibilité temporaire après ramassage, conformément aux recommandations du plan【443107290259958†screenshot】. Les bonus s’attachent occasionnellement à un obstacle et sont récupérés lorsque le capybara les touche, accordant des points supplémentaires ou une invincibilité temporaire.
   * Intégration d’effets sonores simples grâce à l’API Web Audio (bip de saut, score, bonus et fin de partie). La première interaction de l’utilisateur déclenche l’initialisation de l’AudioContext, en accord avec les contraintes des navigateurs mobiles.
@@ -25,7 +25,7 @@ Ce journal retrace les différentes étapes de développement du jeu **Flappy C
 
 **Agent Gestionnaire / Documentaliste**
 
-* Compression finale du projet en archive `flappy_capybara.tar.gz` pour distribution.  La structure complète comprend le code du jeu (`index.html`, `main.js`, `style.css`), les fichiers de documentation (`README.md`, `agents.md`, `progress_log.md`, `CHANGELOG.md` et `tree.txt`) et un dossier `assets/` prêt à recevoir d’éventuelles ressources supplémentaires.
+* Compression finale du projet en archive `flappy_capybara.tar.gz` pour distribution.  La structure complète comprend le code du jeu (`index.html`, `main.js`, `style_v2.css`), les fichiers de documentation (`README.md`, `agents.md`, `progress_log.md`, `CHANGELOG.md` et `tree.txt`) et un dossier `assets/` prêt à recevoir d’éventuelles ressources supplémentaires.
 * Test rapide du jeu dans un navigateur local pour vérifier le bon fonctionnement du menu, du gameplay, de la génération d’obstacles et de bonus, des sons et des écrans de fin de partie.
 * Synchronisation du fichier archive avec l’utilisateur via l’outil `computer.sync_file`.
 
@@ -51,7 +51,7 @@ Ce journal retrace les différentes étapes de développement du jeu **Flappy C
 * Renommage complet du mode « Enedis » en **mode « Ragondin Véhicule »** afin de supprimer toute référence textuelle à une marque.  Les clés de stockage du score ont été renommées en `capyVehicleHighScore` et les fichiers `enedis.html`/`enedis.js` sont désormais remplacés par `energy.html`/`energy.js`.
 * **Amélioration du runner** : repositionnement des pattes du capybara du mode course pour qu’elles soient attachées au corps et animation plus rapide des pattes au sol.  Limitation du saut à deux impulsions avant de toucher le sol.  Ajustement de la taille du canvas (environ 80 % de la hauteur de l’écran) pour une meilleure utilisation de l’espace sur mobile et desktop.
 * **Ajout de messages ludiques** : les écrans de Game Over affichent désormais une anecdote humoristique sur le fromage accompagnée d’un visuel réutilisé (capybara ou marais), sélectionnés aléatoirement parmi une liste variée afin d’offrir un contenu différent à chaque fin de partie.
-* **Mise à jour de `style.css`** : le sélecteur du canvas pour le mode véhicule est passé de `#enedisCanvas` à `#energyCanvas` et de légers ajustements ont été réalisés pour harmoniser les marges et le centrage des canvases.
+* **Mise à jour de `style_v2.css`** : le sélecteur du canvas pour le mode véhicule est passé de `#enedisCanvas` à `#energyCanvas` et de légers ajustements ont été réalisés pour harmoniser les marges et le centrage des canvases.
 * Mise à jour de `README.md`, `tree.txt` et du `CHANGELOG.md` pour documenter ces évolutions.
 
 **Agent Designer / Développeur**
@@ -199,7 +199,7 @@ Ce journal retrace les différentes étapes de développement du jeu **Flappy C
 * **Interface tactile** : ajout d’un conteneur `mobile-controls` dans `platform.html` comportant des boutons circulaires gauche/droite/saut afin de jouer au nouveau mode sur mobile sans clavier.  Les événements `touchstart` et `touchend` ont été ajoutés dans `platform.js` pour gérer ces contrôles.
 * **Amélioration du capybara vectoriel** : repositionnement et agrandissement de l’oreille du capybara dans les dessins vectoriels de tous les modes (`main.js`, `runner.js`, `energy.js` et `platform.js`).  La forme et la couleur de l’oreille ont été revues pour éviter l’effet de museau mal placé.
 * **Prolongation du mode ragondin fatigué** : allongement de la durée avant que le chat ne rattrape le capybara (1 400 frames au lieu de 800) et prolongation de la pluie de cœurs (360 frames au lieu de 240) afin que le joueur puisse profiter plus longtemps de la promenade.  Mise à jour de la logique dans `runner.js` pour refléter ces changements.
-* **Amélioration de l’interface et des graphismes** : restructuration du CSS (`style.css`) pour accueillir le nouveau menu et les cartes de jeux.  Le fond du site est désormais un dégradé pastel et les cartes ont été ombrées pour mieux ressortir.  Ajout d’une image héroïque dans les assets (`menu_hero.png`) et mise à jour de l’arborescence dans `tree.txt` pour inclure toutes les nouvelles ressources et fichiers (`platform.html`, `platform.js`, nouveaux PNG de capybaras et obstacles).  Mise à jour de la documentation (`README.md`, `CHANGELOG.md`, `tree.txt`) pour décrire ces changements.
+* **Amélioration de l’interface et des graphismes** : restructuration du CSS (`style_v2.css`) pour accueillir le nouveau menu et les cartes de jeux.  Le fond du site est désormais un dégradé pastel et les cartes ont été ombrées pour mieux ressortir.  Ajout d’une image héroïque dans les assets (`menu_hero.png`) et mise à jour de l’arborescence dans `tree.txt` pour inclure toutes les nouvelles ressources et fichiers (`platform.html`, `platform.js`, nouveaux PNG de capybaras et obstacles).  Mise à jour de la documentation (`README.md`, `CHANGELOG.md`, `tree.txt`) pour décrire ces changements.
 
 ## 6 août 2025
 

--- a/Capy/docs/tree.txt
+++ b/Capy/docs/tree.txt
@@ -28,5 +28,5 @@ flappy_capybara/
   progress_log.md
   runner.html
   runner.js
-  style.css
+  style_v2.css
   tree.txt

--- a/Capy/energy.html
+++ b/Capy/energy.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Ragon électrique</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="true">
     <!-- Bouton de volume toujours visible -->

--- a/Capy/flappy.html
+++ b/Capy/flappy.html
@@ -2,11 +2,11 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- Empêcher l'indexation automatique de cette page de jeu. -->
     <meta name="robots" content="noindex,nofollow" />
     <title>Flying Capy</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="true" data-game="flappy">
     <!-- Bouton muet : masque le son du jeu.  Utilisé uniquement pour les effets

--- a/Capy/flappy_phaser.html
+++ b/Capy/flappy_phaser.html
@@ -2,10 +2,10 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Flying Capy – Phaser</title>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body>
     <script src="flappy_phaser.js"></script>

--- a/Capy/games.html
+++ b/Capy/games.html
@@ -2,13 +2,13 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Capy Games : collection de mini-jeux gratuits mettant à l'honneur les capybaras." />
     <meta name="keywords" content="capybara, jeux, arcade, logique, casino, capy games" />
     <title>Capy Games</title>
     <!-- La feuille de style principale se trouve un niveau au‑dessus du dossier Capy -->
     <!-- Mettre à jour les chemins des ressources : le reste du site a été déplacé dans le dossier Capy. -->
-    <link rel="stylesheet" href="../Capy/style.css" />
+    <link rel="stylesheet" href="../Capy/style_v2.css" />
     <script>
       (function() {
         function setVh() {

--- a/Capy/gign.html
+++ b/Capy/gign.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy GIGN</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- Le jeu Capy GIGN peut être joué en mode portrait ou paysage.  Il
        utilise une grille de démineur et un capybara en uniforme sur le

--- a/Capy/legal.html
+++ b/Capy/legal.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Mentions légales</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="false">
     <div class="overlay" style="background: rgba(0,0,0,0.65);">

--- a/Capy/platform.html
+++ b/Capy/platform.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Super Capy</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="true">
     <!-- Bouton muet (communs à tous les modes) -->

--- a/Capy/puzzle.html
+++ b/Capy/puzzle.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy Puzzle</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- Le puzzle est un jeu calme et accessible, jouable aussi bien en portrait
        qu'en paysage.  On ne force pas l'orientation. -->

--- a/Capy/roulette.html
+++ b/Capy/roulette.html
@@ -2,11 +2,11 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- Balise noindex afin de limiter l'indexation et le scraping automatique. -->
     <meta name="robots" content="noindex,nofollow" />
     <title>Capy Roulette</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
     <style>
       /* Mise en forme spécifique à la roulette.  Utilise une palette
          sobre et un conteneur responsive pour assurer une bonne

--- a/Capy/runner.html
+++ b/Capy/runner.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capybara Runner</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="true">
     <!-- Bouton muet : bascule les effets sonores.  La musique d'ambiance

--- a/Capy/style_v2.css
+++ b/Capy/style_v2.css
@@ -3,7 +3,9 @@ html,
 body {
   margin: 0;
   padding: 0;
+  height: -webkit-fill-available;
   min-height: calc(var(--vh, 1vh) * 100);
+  min-height: 100dvh;
   /* Fond clair et chaleureux pour le site : dégradé pastel.  Ce fond
      améliore l'accueil et se marie avec les décors des jeux. */
   background: linear-gradient(#e3f2fd, #ffffff);
@@ -97,6 +99,7 @@ body {
   left: 0;
   width: 100%;
   min-height: calc(var(--vh, 1vh) * 100);
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/Capy/supercapy.html
+++ b/Capy/supercapy.html
@@ -2,11 +2,11 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- Empêcher l'indexation automatique de cette page de sélection de niveaux -->
     <meta name="robots" content="noindex,nofollow" />
     <title>Super Capy – Niveaux</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="false" data-no-prestart="true">
     <div id="supercapy-menu" class="overlay">

--- a/Capy/swat.html
+++ b/Capy/swat.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy Swat</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- Capy Swat peut être joué en mode portrait ou paysage -->
   <body data-force-landscape="false">

--- a/Capy/tap.html
+++ b/Capy/tap.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Capy Ninja</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <!-- Capy Tap fonctionne en portrait et paysage.  On ne force pas
        l'orientation. -->

--- a/Capy/tap_phaser.html
+++ b/Capy/tap_phaser.html
@@ -2,10 +2,10 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Tap Capy – Phaser</title>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body>
     <script src="tap_phaser.js"></script>

--- a/Capy/veggie.html
+++ b/Capy/veggie.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Veggie Crush</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="false">
     <button id="volume-toggle" class="volume-btn">🔊</button>

--- a/Capy/whack.html
+++ b/Capy/whack.html
@@ -2,9 +2,9 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Whack‑a‑Capy</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style_v2.css" />
   </head>
   <body data-force-landscape="false">
     <div id="whack-container">

--- a/capygames.html
+++ b/capygames.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Capy Games : collection de jeux gratuits mettant en scène des capybaras." />
     <meta name="keywords" content="capybara, jeux gratuits, mini-jeux, capy games" />
     <title>Capy Games</title>

--- a/courgette/clicker.html
+++ b/courgette/clicker.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Courgette Clicker</title>
     <!-- Empêcher l'indexation automatique de cette page afin de réduire sa
          visibilité dans les moteurs de recherche et de compliquer les opérations

--- a/courgette/clicker/index.html
+++ b/courgette/clicker/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Courgette Clicker</title>
     <!-- Empêcher l'indexation automatique de cette page afin de réduire sa
          visibilité dans les moteurs de recherche et de compliquer les opérations

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Capy Games : collection de jeux gratuits mettant en scène des capybaras." />
     <meta name="keywords" content="capybara, jeux gratuits, mini-jeux, capy games" />
     <title>Capy Games</title>


### PR DESCRIPTION
## Summary
- ensure all pages include `viewport-fit=cover` for better mobile support
- rename main stylesheet to `style_v2.css` and update paths to force CDN refresh
- adjust CSS to use dynamic viewport units and `-webkit-fill-available` to prevent mobile cropping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895134d48b8832cb62b980e6436ae36