### PR TITLE
Hide images in Capy Match until card is revealed

### DIFF
--- a/Capy/style_v2.css
+++ b/Capy/style_v2.css
@@ -1189,9 +1189,13 @@ body.dark-mode .dark-mode-toggle:hover {
   width: 60px;
   height: 60px;
   pointer-events: none;
+  opacity: 0;
 }
 .match-card.revealed {
   background: #fff;
+}
+.match-card.revealed img {
+  opacity: 1;
 }
 .match-card.matched {
   visibility: hidden;


### PR DESCRIPTION
## Summary
- hide Capy Match card images until a card is flipped

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952907c158832c99c3680d8e56951d