### PR TITLE
feat: reactivate seed and special shops

### DIFF
--- a/courgette/clicker.html
+++ b/courgette/clicker.html
@@ -44,9 +44,18 @@
         <div id="progress-bar" class="progress-bar"></div>
       </div>
 
-        <!-- Options: sound, animation, language selection -->
-        <div id="options" class="options" role="toolbar" aria-label="Options de jeu">
+      <!-- Options: sound, animation, language selection -->
+      <div id="options" class="options" role="toolbar" aria-label="Options de jeu">
         <!-- Boutons de navigation : options (settings), succès, boosts globaux -->
+        <button id="settings-btn" class="settings-btn" aria-label="Options">
+          <span class="emoji-btn" aria-hidden="true">⚙️</span>
+        </button>
+        <button id="achievements-btn" class="achievements-btn" aria-label="Succès">
+          <span class="emoji-btn" aria-hidden="true">🏆</span>
+        </button>
+        <button id="global-upgrades-btn" class="global-upgrades-btn" aria-label="Boutique">
+          <span class="emoji-btn" aria-hidden="true">🛒</span>
+        </button>
       </div>
       <div id="clicker-area" class="clicker-area">
         <!-- Zone interactive : Courgette‑chan est composée de plusieurs calques (corps, bras, expression, overlay).
@@ -99,6 +108,10 @@
         <div class="prestige-actions">
           <button id="prestige-btn" class="prestige-btn" data-i18n="prestigeBtn"></button>
           <!-- Button to open the seeds shop. Shows the amount of seeds owned. -->
+          <button id="seeds-shop-btn" class="seeds-btn" aria-label="Boutique des graines">
+            <img src="assets/icon_seeds.png" alt="" />
+            <span id="seeds-amount">0</span>
+          </button>
         </div>
         <div id="prestige-info" class="prestige-info"></div>
       </div>

--- a/courgette/clicker/css/style_v2.css
+++ b/courgette/clicker/css/style_v2.css
@@ -1092,29 +1092,11 @@ body.high-contrast .seeds-item button.unaffordable {
 }
 
 /* Achievements button near the settings: rendered as a circular icon with a trophy image inside. */
-.achievements-btn {
-  background: none;
-  border: none;
-  width: 40px;
-  height: 40px;
-  padding: 0;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-.achievements-btn:hover {
-  background-color: rgba(0, 0, 0, 0.08);
-}
-.achievements-btn img {
-  width: 28px;
-  height: 28px;
-}
 
-/* Paramètres (settings) button */
-.settings-btn {
+/* Boutons circulaires dans la barre d'options (succès, paramètres, boutique) */
+.achievements-btn,
+.settings-btn,
+.global-upgrades-btn {
   background: none;
   border: none;
   width: 40px;
@@ -1127,10 +1109,14 @@ body.high-contrast .seeds-item button.unaffordable {
   cursor: pointer;
   transition: background-color 0.2s;
 }
-.settings-btn:hover {
+.achievements-btn:hover,
+.settings-btn:hover,
+.global-upgrades-btn:hover {
   background-color: rgba(0, 0, 0, 0.08);
 }
-.settings-btn img {
+.achievements-btn img,
+.settings-btn img,
+.global-upgrades-btn img {
   width: 28px;
   height: 28px;
 }

--- a/courgette/clicker/index.html
+++ b/courgette/clicker/index.html
@@ -57,6 +57,9 @@
           <!-- Icône succès remplacée par un emoji trophée -->
           <span class="emoji-btn" aria-hidden="true">🏆</span>
         </button>
+        <button id="global-upgrades-btn" class="global-upgrades-btn" aria-label="Boutique">
+          <span class="emoji-btn" aria-hidden="true">🛒</span>
+        </button>
       </div>
       <div id="clicker-area" class="clicker-area">
         <!-- Zone interactive : Courgette‑chan est composée de plusieurs calques (corps, bras, expression, overlay).
@@ -109,6 +112,10 @@
         <div class="prestige-actions">
           <button id="prestige-btn" class="prestige-btn" data-i18n="prestigeBtn"></button>
           <!-- Button to open the seeds shop. Shows the amount of seeds owned. -->
+          <button id="seeds-shop-btn" class="seeds-btn" aria-label="Boutique des graines">
+            <img src="../assets/icon_seeds.png" alt="" />
+            <span id="seeds-amount">0</span>
+          </button>
         </div>
         <div id="prestige-info" class="prestige-info"></div>
       </div>

--- a/courgette/css/style_v2.css
+++ b/courgette/css/style_v2.css
@@ -1093,29 +1093,11 @@ body.high-contrast .seeds-item button.unaffordable {
 }
 
 /* Achievements button near the settings: rendered as a circular icon with a trophy image inside. */
-.achievements-btn {
-  background: none;
-  border: none;
-  width: 40px;
-  height: 40px;
-  padding: 0;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-.achievements-btn:hover {
-  background-color: rgba(0, 0, 0, 0.08);
-}
-.achievements-btn img {
-  width: 28px;
-  height: 28px;
-}
 
-/* Paramètres (settings) button */
-.settings-btn {
+/* Boutons circulaires dans la barre d'options (succès, paramètres, boutique) */
+.achievements-btn,
+.settings-btn,
+.global-upgrades-btn {
   background: none;
   border: none;
   width: 40px;
@@ -1128,10 +1110,14 @@ body.high-contrast .seeds-item button.unaffordable {
   cursor: pointer;
   transition: background-color 0.2s;
 }
-.settings-btn:hover {
+.achievements-btn:hover,
+.settings-btn:hover,
+.global-upgrades-btn:hover {
   background-color: rgba(0, 0, 0, 0.08);
 }
-.settings-btn img {
+.achievements-btn img,
+.settings-btn img,
+.global-upgrades-btn img {
   width: 28px;
   height: 28px;
 }


### PR DESCRIPTION
## Summary
- reintroduce global upgrades button to access special item shop
- add seed shop button with seed counter and aubergine offer
- style new option button alongside existing controls

## Testing
- `node --version`
- `node --check courgette/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68953b9a7348832c985b8cad05f90a43