### PR TITLE
Hide Capy Battle from main menu

### DIFF
--- a/Capy/menu.js
+++ b/Capy/menu.js
@@ -197,16 +197,6 @@
       page: 'roulette.html',
       category: 'casino',
       image: 'assets/roulette_icon.png'
-    }
-    ,
-    // Mini-jeu de bataille simple avec animations et retour positif.
-    {
-      id: 'battle',
-      title: 'Capy Battle',
-      scoreKey: 'capyBattleHighScore',
-      page: 'battle.html',
-      category: 'arcade',
-      image: 'assets/capybara_super.png'
     },
     {
       id: 'lights',


### PR DESCRIPTION
## Summary
- remove Capy Battle entry from game list to keep battle engine internal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953bd42e8c832c90c9643d97eda3a9