### PR TITLE
feat(match): enhance difficulty and feedback

### DIFF
--- a/Capy/match.html
+++ b/Capy/match.html
@@ -9,9 +9,10 @@
   <body data-force-landscape="false">
     <button id="volume-toggle" class="volume-btn">🔇</button>
     <div id="match-container" class="courgette-container">
-      <div id="match-grid" class="match-grid"></div>
+      <div id="match-grid" class="match-grid courgette-board"></div>
       <div class="courgette-sidebar">
-        <p>Paires : <span id="match-pairs">0</span>/4</p>
+        <p>Niveau : <span id="match-level">1</span></p>
+        <p>Paires : <span id="match-pairs">0</span>/<span id="match-total">0</span></p>
         <p>Temps : <span id="match-time">0</span>s</p>
         <button id="match-restart" class="btn">Rejouer</button>
         <button id="match-menu" class="btn">Menu</button>
@@ -23,8 +24,18 @@
         <p><strong>Temps :</strong> <span id="match-current-time">0</span>s</p>
         <p><strong>Record :</strong> <span id="match-high-score">–</span>s</p>
         <div class="button-group">
-          <button id="match-over-replay" class="btn">Rejouer</button>
+          <button id="match-over-next" class="btn">Suivant</button>
           <button id="match-over-menu" class="btn">Menu</button>
+        </div>
+      </div>
+    </div>
+    <div id="match-lose" class="overlay hidden">
+      <div class="menu-card">
+        <h1>Perdu !</h1>
+        <p>Réessayez pour améliorer votre score.</p>
+        <div class="button-group">
+          <button id="match-lose-replay" class="btn">Rejouer</button>
+          <button id="match-lose-menu" class="btn">Menu</button>
         </div>
       </div>
     </div>

--- a/Capy/match.js
+++ b/Capy/match.js
@@ -1,16 +1,34 @@
 (() => {
-  const images = [
+  const allImages = [
     'assets/veg_carrot_final.png',
     'assets/veg_courgette_final.png',
     'assets/veg_pepper_final.png',
-    'assets/veg_tomato_final.png'
+    'assets/veg_tomato_final.png',
+    'assets/veg_potato_final.png',
+    'assets/capybara_penguin.png',
+    'assets/capybara_ninja_new.png',
+    'assets/capybara_super.png',
+    'assets/capybara_electric.png',
+    'assets/capybara_unicorn.png',
+    'assets/capybara_flying_new.png',
+    'assets/capybara_turtle.png'
   ];
+  let level = 1;
+  let pairsTarget = 6;
   let deck = [];
   let first = null;
   let lock = false;
   let pairs = 0;
-  let time = 0;
+  let timeLeft = 0;
+  let elapsed = 0;
   let timer = null;
+  const baseTime = 60;
+  let isMuted = false;
+  const flipSound = new Audio('../courgette/assets/audio/click.mp3');
+  const matchSound = new Audio('../courgette/assets/audio/achievement.mp3');
+  const winSound = new Audio('../courgette/assets/audio/event.mp3');
+  const loseSound = new Audio('../courgette/assets/audio/moan.mp3');
+  const volumeBtn = document.getElementById('volume-toggle');
 
   function shuffle(arr) {
     for (let i = arr.length - 1; i > 0; i--) {
@@ -21,9 +39,12 @@
   }
 
   function buildDeck() {
-    deck = shuffle(images.concat(images));
+    const selected = shuffle(allImages.slice()).slice(0, pairsTarget);
+    deck = shuffle(selected.concat(selected));
     const grid = document.getElementById('match-grid');
     grid.innerHTML = '';
+    const cols = Math.ceil(Math.sqrt(deck.length));
+    grid.style.gridTemplateColumns = `repeat(${cols}, 70px)`;
     deck.forEach((src, idx) => {
       const card = document.createElement('div');
       card.className = 'match-card';
@@ -39,12 +60,8 @@
 
   function onCard(card) {
     if (lock || card.classList.contains('revealed') || card.classList.contains('matched')) return;
-    if (!timer) {
-      timer = setInterval(() => {
-        time++;
-        document.getElementById('match-time').textContent = time;
-      }, 1000);
-    }
+    flipSound.currentTime = 0;
+    flipSound.play();
     card.classList.add('revealed');
     if (!first) {
       first = card;
@@ -56,12 +73,20 @@
         if (same) {
           first.classList.add('matched');
           second.classList.add('matched');
+          matchSound.currentTime = 0;
+          matchSound.play();
           pairs++;
           document.getElementById('match-pairs').textContent = pairs;
           if (pairs === deck.length / 2) endGame();
         } else {
-          first.classList.remove('revealed');
-          second.classList.remove('revealed');
+          first.classList.add('shake');
+          second.classList.add('shake');
+          setTimeout(() => {
+            first.classList.remove('shake');
+            second.classList.remove('shake');
+            first.classList.remove('revealed');
+            second.classList.remove('revealed');
+          }, 300);
         }
         first = null;
         lock = false;
@@ -69,39 +94,107 @@
     }
   }
 
+  function getGlobalVolume() {
+    let v = 0.5;
+    try {
+      const stored = localStorage.getItem('capyVolume');
+      if (stored !== null) v = parseFloat(stored);
+    } catch (e) {}
+    return v;
+  }
+
+  function applyVolume() {
+    const vol = isMuted ? 0 : getGlobalVolume();
+    [flipSound, matchSound, winSound, loseSound].forEach((a) => (a.volume = vol));
+  }
+
+  if (volumeBtn) {
+    volumeBtn.addEventListener('click', () => {
+      isMuted = !isMuted;
+      volumeBtn.textContent = isMuted ? '🔇' : '🔊';
+      applyVolume();
+    });
+    volumeBtn.textContent = '🔊';
+  }
+  applyVolume();
+
   function init() {
     pairs = 0;
-    time = 0;
+    timeLeft = Math.max(20, baseTime - (level - 1) * 5);
+    elapsed = 0;
     first = null;
     lock = false;
     document.getElementById('match-pairs').textContent = '0';
-    document.getElementById('match-time').textContent = '0';
+    document.getElementById('match-total').textContent = pairsTarget;
+    document.getElementById('match-level').textContent = level;
+    document.getElementById('match-time').textContent = timeLeft;
     if (timer) clearInterval(timer);
-    timer = null;
+    timer = setInterval(() => {
+      timeLeft--;
+      elapsed++;
+      document.getElementById('match-time').textContent = timeLeft;
+      if (timeLeft <= 0) loseGame();
+    }, 1000);
     buildDeck();
   }
 
   function endGame() {
     clearInterval(timer);
-    document.getElementById('match-current-time').textContent = time;
+    winSound.currentTime = 0;
+    winSound.play();
+    document.getElementById('match-current-time').textContent = elapsed;
     let best = parseInt(localStorage.getItem('capyMatchHighScore') || '0', 10);
-    if (!best || time < best) {
-      localStorage.setItem('capyMatchHighScore', time);
-      best = time;
+    if (!best || elapsed < best) {
+      localStorage.setItem('capyMatchHighScore', elapsed);
+      best = elapsed;
     }
     document.getElementById('match-high-score').textContent = best;
-    document.getElementById('match-gameover').classList.remove('hidden');
+    showOverlay('match-gameover');
   }
 
-  document.getElementById('match-restart').addEventListener('click', init);
-  document.getElementById('match-over-replay').addEventListener('click', () => {
-    document.getElementById('match-gameover').classList.add('hidden');
+  function loseGame() {
+    clearInterval(timer);
+    loseSound.currentTime = 0;
+    loseSound.play();
+    showOverlay('match-lose');
+  }
+
+  function showOverlay(id) {
+    const el = document.getElementById(id);
+    el.classList.remove('hidden');
+    el.classList.add('show');
+  }
+
+  function hideOverlay(id) {
+    const el = document.getElementById(id);
+    el.classList.add('hidden');
+    el.classList.remove('show');
+  }
+
+  document.getElementById('match-restart').addEventListener('click', () => {
+    level = 1;
+    pairsTarget = 6;
+    init();
+  });
+  document.getElementById('match-over-next').addEventListener('click', () => {
+    hideOverlay('match-gameover');
+    level++;
+    pairsTarget = Math.min(allImages.length, pairsTarget + 1);
+    init();
+  });
+  document.getElementById('match-over-menu').addEventListener('click', () => {
+    window.location.href = 'games.html';
+  });
+  document.getElementById('match-lose-replay').addEventListener('click', () => {
+    hideOverlay('match-lose');
+    level = 1;
+    pairsTarget = 6;
     init();
   });
   document.getElementById('match-menu').addEventListener('click', () => {
     window.location.href = 'games.html';
   });
-  document.getElementById('match-over-menu').addEventListener('click', () => {
+  document.getElementById('match-lose-menu').addEventListener('click', () => {
     window.location.href = 'games.html';
   });
   document.getElementById('match-instructions-ok').addEventListener('click', () => {

--- a/Capy/style_v3.css
+++ b/Capy/style_v3.css
@@ -1174,7 +1174,6 @@ body.dark-mode .dark-mode-toggle:hover {
 /* ---------------------- Capy Match ---------------------- */
 .match-grid {
   display: grid;
-  grid-template-columns: repeat(4, 70px);
   gap: 8px;
   padding: 8px;
   justify-content: center;
@@ -1189,6 +1188,7 @@ body.dark-mode .dark-mode-toggle:hover {
   justify-content: center;
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  transition: transform 0.3s, background 0.3s;
 }
 .match-card img {
   width: 60px;
@@ -1198,12 +1198,34 @@ body.dark-mode .dark-mode-toggle:hover {
 }
 .match-card.revealed {
   background: #fff;
+  transform: scale(1.05);
 }
 .match-card.revealed img {
   opacity: 1;
 }
 .match-card.matched {
-  visibility: hidden;
+  animation: match-pop 0.5s forwards;
+}
+.match-card.shake {
+  animation: shake 0.4s;
+}
+
+@keyframes match-pop {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.2); }
+  100% { transform: scale(0); opacity: 0; }
+}
+@keyframes shake {
+  0%,100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  75% { transform: translateX(5px); }
+}
+.overlay.show .menu-card {
+  animation: overlay-pop 0.5s;
+}
+@keyframes overlay-pop {
+  from { transform: scale(0.7); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
 }
 
 /* ---------------------- Capy Scramble ---------------------- */


### PR DESCRIPTION
## Summary
- increase Capy Match challenge with more card images and progressive levels
- add win/lose overlays with animations and courgette clicker sounds
- polish UI and animations for cards and dialogs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689548917fa0832c90359450fb8faa1d