### PR TITLE
feat: streamline home tabs and battle visuals

### DIFF
--- a/Capy/battle.js
+++ b/Capy/battle.js
@@ -16,10 +16,12 @@
     onEnd = null,
     menuAction = null,
     playerName = 'Capy',
-    enemyName = 'Ennemi'
+    enemyName = 'Ennemi',
+    playerHpStart = 100,
+    enemyHpStart = 100
   } = {}) {
-    let playerHp = 100;
-    let enemyHp = 100;
+    let playerHp = playerHpStart;
+    let enemyHp = enemyHpStart;
     if (playerNameEl) playerNameEl.textContent = playerName;
     if (enemyNameEl) enemyNameEl.textContent = enemyName;
     let inBattle = true;

--- a/Capy/capymon.js
+++ b/Capy/capymon.js
@@ -235,7 +235,7 @@
     battleCssInjected = true;
   }
 
-  function launchCapyBattle(playerSrc, enemySrc, onEnd) {
+  function launchCapyBattle(playerSrc, enemySrc, playerName, enemyName, playerHp, enemyHp, onEnd) {
     injectBattleCss();
     const overlay = document.createElement('div');
     overlay.id = 'capy-simple-battle';
@@ -273,6 +273,10 @@
       restartBtn: overlay.querySelector('#restart-btn'),
       resultText: overlay.querySelector('#result-text'),
       starImg: overlay.querySelector('.star'),
+      playerName: playerName,
+      enemyName: enemyName,
+      playerHpStart: playerHp,
+      enemyHpStart: enemyHp,
       menuAction: () => {
         overlay.remove();
         if (onEnd) onEnd(false);
@@ -302,9 +306,14 @@
       }
       if (!speciesKey) speciesKey = 'capybara';
     }
-    const playerSrc = (playerCapys[currentCapyIndex] && speciesImages[playerCapys[currentCapyIndex].species]) ? speciesImages[playerCapys[currentCapyIndex].species].src : 'assets/capybara_super.png';
+    const playerCapy = playerCapys[currentCapyIndex];
+    const playerSrc = (playerCapy && speciesImages[playerCapy.species]) ? speciesImages[playerCapy.species].src : 'assets/capybara_super.png';
     const enemySrc = speciesImages[speciesKey] ? speciesImages[speciesKey].src : 'assets/capybara_turtle.png';
-    launchCapyBattle(playerSrc, enemySrc, (victory) => {
+    const playerName = playerCapy ? playerCapy.name : 'Capy';
+    const enemyName = speciesData[speciesKey] ? speciesData[speciesKey].name : speciesKey;
+    const playerHp = playerCapy ? Math.round((playerCapy.currentHP / playerCapy.maxHP) * 100) : 100;
+    const enemyHp = 100;
+    launchCapyBattle(playerSrc, enemySrc, playerName, enemyName, playerHp, enemyHp, (victory) => {
       stopBattleMusic();
       inBattle = false;
       draw();

--- a/Capy/games.html
+++ b/Capy/games.html
@@ -50,11 +50,10 @@
         <h1>Capy Games</h1>
         <!-- Catégories de jeux -->
         <div id="menu-categories" class="menu-categories" role="navigation" aria-label="Catégories des jeux">
-          <button class="category-btn" data-category="featured">⭐ En vedette ⭐</button>
+          <button class="category-btn active" data-category="featured">⭐ En vedette ⭐</button>
           <button class="category-btn" data-category="arcade">Arcade</button>
           <button class="category-btn" data-category="logique">Logique</button>
           <button class="category-btn" data-category="casino">Casino</button>
-          <button class="category-btn active" data-category="all">Tous</button>
         </div>
         <!-- Liste des jeux générée dynamiquement par menu.js -->
         <div id="game-list" class="game-list"></div>

--- a/Capy/menu.js
+++ b/Capy/menu.js
@@ -369,12 +369,10 @@
       categoryButtons.forEach((b) => b.classList.toggle('active', b === btn));
       document.querySelectorAll('.game-card').forEach((card) => {
         // Filtrage par catégorie : pour l’onglet “featured”, on sélectionne
-        // uniquement les cartes marquées data-featured=true.  Pour “all”,
-        // on affiche tout.  Sinon on compare la catégorie de la carte.
+        // uniquement les cartes marquées data-featured=true.  Sinon on compare
+        // simplement la catégorie de la carte.
         if (target === 'featured') {
           card.style.display = card.dataset.featured === 'true' ? '' : 'none';
-        } else if (target === 'all') {
-          card.style.display = '';
         } else {
           card.style.display = (card.dataset.category === target) ? '' : 'none';
         }
@@ -399,6 +397,10 @@
       }
     });
   });
+
+  // Afficher par défaut les jeux en vedette à l’arrivée sur la page
+  const defaultBtn = document.querySelector('.category-btn[data-category="featured"]');
+  if (defaultBtn) defaultBtn.click();
 
   // Afficher une citation drôle sous le menu.  Quelques phrases sont
   // sélectionnées aléatoirement parmi une liste définie ci‑dessous.  Seules

--- a/Capy/style_v3.css
+++ b/Capy/style_v3.css
@@ -555,6 +555,9 @@ body[data-game="flappy"] .volume-btn {
   max-height: calc(100dvh - 300px);
   max-height: calc(-webkit-fill-available - 300px);
   overflow-y: auto;
+  /* Éviter que les gestes de défilement entrent en conflit avec les cartes. */
+  touch-action: pan-y;
+  overscroll-behavior: contain;
 }
 
 /* Carte représentant un jeu dans la liste du menu */


### PR DESCRIPTION
## Summary
- Remove "Tous" tab and land visitors on featured games by default
- Stabilize arcade slider to prevent card collisions
- Use Capy Battle graphics with proper names and HP in Capy Mon battles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68954b7b96d0832c8344e0d21474db32