### PR TITLE
Reset clears all Courgette Clicker data and fix Aubergine skin purchase popup

### DIFF
--- a/courgette/clicker/css/style_v3.css
+++ b/courgette/clicker/css/style_v3.css
@@ -1563,6 +1563,9 @@ body.high-contrast .capygames-link a {
   font-weight: bold;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  text-decoration: none;
+  text-align: center;
+  display: inline-block;
 }
 .paypal-btn:hover {
   background-color: #d4ac0d;

--- a/courgette/css/style_v3.css
+++ b/courgette/css/style_v3.css
@@ -1567,6 +1567,9 @@ body.high-contrast .capygames-link a {
   font-weight: bold;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  text-decoration: none;
+  text-align: center;
+  display: inline-block;
 }
 .paypal-btn:hover {
   background-color: #d4ac0d;


### PR DESCRIPTION
## Summary
- Ensure the reset button wipes all Courgette Clicker data, including settings, challenges, and caches.
- Show Aubergine skin offer with a PayPal-style link that opens in a new tab and unlocks the skin.
- Style PayPal button link to render like the existing buttons.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68954c393938832c980a51e1bcc985f6