### PR TITLE
fix: improve Capy Match rules

### DIFF
--- a/Capy/match.html
+++ b/Capy/match.html
@@ -14,6 +14,7 @@
         <p>Niveau : <span id="match-level">1</span></p>
         <p>Paires : <span id="match-pairs">0</span>/<span id="match-total">0</span></p>
         <p>Temps : <span id="match-time">0</span>s</p>
+        <p>Essais restants : <span id="match-attempts">0</span></p>
         <button id="match-restart" class="btn">Rejouer</button>
         <button id="match-menu" class="btn">Menu</button>
       </div>
@@ -42,7 +43,7 @@
     <div id="match-instructions" class="overlay hidden">
       <div class="menu-card">
         <h2>Capy Match – Règles</h2>
-        <p>Retournez les cartes et retrouvez toutes les paires de légumes identiques. Essayez de terminer en un minimum de temps !</p>
+        <p>Retournez les cartes et retrouvez toutes les paires identiques en un minimum de temps. Vous disposez d'un nombre limité d'essais, utilisez-les judicieusement !</p>
         <button id="match-instructions-ok" class="btn">Ok</button>
       </div>
     </div>

--- a/Capy/match.js
+++ b/Capy/match.js
@@ -21,6 +21,7 @@
   let pairs = 0;
   let timeLeft = 0;
   let elapsed = 0;
+  let attemptsLeft = 0;
   let timer = null;
   const baseTime = 60;
   let isMuted = false;
@@ -78,6 +79,8 @@
           pairs++;
           document.getElementById('match-pairs').textContent = pairs;
           if (pairs === deck.length / 2) endGame();
+          first = null;
+          lock = false;
         } else {
           first.classList.add('shake');
           second.classList.add('shake');
@@ -86,10 +89,13 @@
             second.classList.remove('shake');
             first.classList.remove('revealed');
             second.classList.remove('revealed');
+            attemptsLeft--;
+            document.getElementById('match-attempts').textContent = attemptsLeft;
+            first = null;
+            lock = false;
+            if (attemptsLeft <= 0) loseGame();
           }, 300);
         }
-        first = null;
-        lock = false;
       }, 600);
     }
   }
@@ -124,10 +130,12 @@
     elapsed = 0;
     first = null;
     lock = false;
+    attemptsLeft = pairsTarget * 2;
     document.getElementById('match-pairs').textContent = '0';
     document.getElementById('match-total').textContent = pairsTarget;
     document.getElementById('match-level').textContent = level;
     document.getElementById('match-time').textContent = timeLeft;
+    document.getElementById('match-attempts').textContent = attemptsLeft;
     if (timer) clearInterval(timer);
     timer = setInterval(() => {
       timeLeft--;


### PR DESCRIPTION
## Summary
- clarify Capy Match rules to mention generic pairs and finite attempts
- ensure mismatched cards flip back and allow retry
- add attempt counter with loss condition

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68954df82e24832c8916dddcf2944649